### PR TITLE
fix miss-typed hyperlink

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -354,7 +354,7 @@ export default function IndexPage() {
         <span>
           <Github /> Made by{' '}
           <a
-            href='http://https://github.com/rajanmagar'
+            href='https://github.com/rajanmagar'
             target='_blank'
             rel='noopener noreferrer'
           >


### PR DESCRIPTION
Github link didn't work at [your deploy page](https://coronaa.netlify.com/)

I fixed miss-typed hyperlink and send this PR.

